### PR TITLE
wasi: nonblocking I/O for sockets and pipes on Windows

### DIFF
--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -478,13 +477,11 @@ func testSock(t *testing.T, bin []byte) {
 	console := <-ch
 	require.NotEqual(t, 0, n)
 	require.NoError(t, err)
-	require.Equal(t, "wazero\n", console)
+	// Nonblocking connections may contain error logging, we ignore those.
+	require.Equal(t, "wazero\n", console[len(console)-7:])
 }
 
 func Test_HTTP(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fsapi.Nonblocking() is not supported on wasip1+windows.")
-	}
 	toolchains := map[string][]byte{}
 	if wasmGotip != nil {
 		toolchains["gotip"] = wasmGotip

--- a/internal/platform/fdset.go
+++ b/internal/platform/fdset.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package platform
 
 // Set adds the given fd to the set.

--- a/internal/platform/fdset_test.go
+++ b/internal/platform/fdset_test.go
@@ -1,17 +1,14 @@
+//go:build !windows
+
 package platform
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestFdSet(t *testing.T) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
-		t.Skip("not supported")
-	}
-
 	allBitsSetAtIndex0 := FdSet{}
 	allBitsSetAtIndex0.Bits[0] = -1
 

--- a/internal/platform/fdset_unsupported.go
+++ b/internal/platform/fdset_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package platform
 

--- a/internal/platform/fdset_windows.go
+++ b/internal/platform/fdset_windows.go
@@ -1,0 +1,209 @@
+package platform
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var procGetNamedPipeInfo = kernel32.NewProc("GetNamedPipeInfo")
+
+// Maximum number of fds in a WinSockFdSet.
+const _FD_SETSIZE = 64
+
+// WinSockFdSet implements the FdSet representation that is used internally by WinSock.
+//
+// Note: this representation is quite different from the one used in most POSIX implementations
+// where a bitfield is usually implemented; instead on Windows we have a simpler array+count pair.
+// Notice that because it keeps a count of the inserted handles, the first argument of select
+// in WinSock is actually ignored.
+//
+// The implementation of the Set, Clear, IsSet, Zero, methods follows exactly
+// the real implementation found in WinSock2.h, e.g. see:
+// https://github.com/microsoft/win32metadata/blob/ef7725c75c6b39adfdc13ba26fb1d89ac954449a/generation/WinSDK/RecompiledIdlHeaders/um/WinSock2.h#L124-L175
+type WinSockFdSet struct {
+	// count is the number of used slots used in the handles slice.
+	count uint64
+	// handles is the array of handles. This is called "array" in the WinSock implementation
+	// and it has a fixed length of _FD_SETSIZE.
+	handles [_FD_SETSIZE]syscall.Handle
+}
+
+// FdSet implements the same methods provided on other plaforms.
+//
+// Note: the implementation is very different from POSIX; Windows provides
+// POSIX select only for sockets. We emulate a select for other APIs in the sysfs
+// package, but we still want to use the "real" select in the case of sockets.
+// So, we keep a separate FdSet of sockets, so that we can pass it directly
+// to the winsock select implementation
+type FdSet struct {
+	sockets WinSockFdSet
+	pipes   WinSockFdSet
+	regular WinSockFdSet
+}
+
+// Sockets returns a WinSockFdSet containing the handles in this FdSet that are sockets.
+func (f *FdSet) Sockets() *WinSockFdSet {
+	if f == nil {
+		return nil
+	}
+	return &f.sockets
+}
+
+func (f *FdSet) SetSockets(s WinSockFdSet) {
+	f.sockets = s
+}
+
+// Regular returns a WinSockFdSet containing the handles in this FdSet that are regular files.
+func (f *FdSet) Regular() *WinSockFdSet {
+	if f == nil {
+		return nil
+	}
+	return &f.regular
+}
+
+func (f *FdSet) SetRegular(r WinSockFdSet) {
+	f.regular = r
+}
+
+// Regular returns a WinSockFdSet containing the handles in this FdSet that are pipes.
+func (f *FdSet) Pipes() *WinSockFdSet {
+	if f == nil {
+		return nil
+	}
+	return &f.pipes
+}
+
+func (f *FdSet) SetPipes(p WinSockFdSet) {
+	f.pipes = p
+}
+
+func (f *FdSet) getFdSetFor(fd int) *WinSockFdSet {
+	h := syscall.Handle(fd)
+	t, err := syscall.GetFileType(h)
+	if err != nil {
+		return nil
+	}
+	switch t {
+	case syscall.FILE_TYPE_CHAR, syscall.FILE_TYPE_DISK:
+		return &f.regular
+	case syscall.FILE_TYPE_PIPE:
+		if isSocket(h) {
+			return &f.sockets
+		} else {
+			return &f.pipes
+		}
+	default:
+		return nil
+	}
+}
+
+// Set adds the given fd to the set.
+func (f *FdSet) Set(fd int) {
+	if s := f.getFdSetFor(fd); s != nil {
+		s.Set(fd)
+	}
+}
+
+// Clear removes the given fd from the set.
+func (f *FdSet) Clear(fd int) {
+	if s := f.getFdSetFor(fd); s != nil {
+		s.Clear(fd)
+	}
+}
+
+// IsSet returns true when fd is in the set.
+func (f *FdSet) IsSet(fd int) bool {
+	if s := f.getFdSetFor(fd); s != nil {
+		return s.IsSet(fd)
+	}
+	return false
+}
+
+// Zero clears the set.
+func (f *FdSet) Zero() {
+	f.sockets.Zero()
+	f.regular.Zero()
+	f.pipes.Zero()
+}
+
+// Set adds the given fd to the set.
+func (f *WinSockFdSet) Set(fd int) {
+	if f.count < _FD_SETSIZE {
+		f.handles[f.count] = syscall.Handle(fd)
+		f.count++
+	}
+}
+
+// Clear removes the given fd from the set.
+func (f *WinSockFdSet) Clear(fd int) {
+	h := syscall.Handle(fd)
+	if !isSocket(h) {
+		return
+	}
+
+	for i := uint64(0); i < f.count; i++ {
+		if f.handles[i] == h {
+			for ; i < f.count-1; i++ {
+				f.handles[i] = f.handles[i+1]
+			}
+			f.count--
+			break
+		}
+	}
+}
+
+// IsSet returns true when fd is in the set.
+func (f *WinSockFdSet) IsSet(fd int) bool {
+	h := syscall.Handle(fd)
+	for i := uint64(0); i < f.count; i++ {
+		if f.handles[i] == h {
+			return true
+		}
+	}
+	return false
+}
+
+// Zero clears the set.
+func (f *WinSockFdSet) Zero() {
+	f.count = 0
+}
+
+func (f *WinSockFdSet) Count() int {
+	if f == nil {
+		return 0
+	}
+	return int(f.count)
+}
+
+func (f *WinSockFdSet) Copy() *WinSockFdSet {
+	if f == nil {
+		return nil
+	}
+	copy := *f
+	return &copy
+}
+
+func (f *WinSockFdSet) Get(index int) syscall.Handle {
+	return f.handles[index]
+}
+
+// isSocket returns true if the given file handle
+// is a pipe.
+func isSocket(fd syscall.Handle) bool {
+	// n, err := syscall.GetFileType(fd)
+	// if err != nil {
+	// 	return false
+	// }
+	// if n != syscall.FILE_TYPE_PIPE {
+	// 	return false
+	// }
+	// If the call to GetNamedPipeInfo succeeds then
+	// the handle is a pipe handle, otherwise it is a socket.
+	r, _, errno := syscall.SyscallN(
+		procGetNamedPipeInfo.Addr(),
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(nil)))
+	return r != 0 && errno == 0
+}

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -49,10 +49,6 @@ func TestStdioFileSetNonblock(t *testing.T) {
 }
 
 func TestRegularFileSetNonblock(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Nonblock on regular files is not supported on Windows")
-	}
-
 	// Test using os.Pipe as it is known to support non-blocking reads.
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
@@ -339,10 +335,6 @@ func TestFilePollRead(t *testing.T) {
 
 	// When there's nothing in the pipe, it isn't ready.
 	ready, errno := rF.PollRead(&timeout)
-	if runtime.GOOS == "windows" {
-		require.EqualErrno(t, experimentalsys.ENOSYS, errno)
-		t.Skip("TODO: windows File.PollRead")
-	}
 	require.EqualErrno(t, 0, errno)
 	require.False(t, ready)
 

--- a/internal/sysfs/file_windows.go
+++ b/internal/sysfs/file_windows.go
@@ -24,15 +24,15 @@ var procPeekNamedPipe = kernel32.NewProc("PeekNamedPipe")
 // https://learn.microsoft.com/en-us/windows/console/console-handles
 func readFd(fd uintptr, buf []byte) (int, sys.Errno) {
 	handle := syscall.Handle(fd)
-	fileType, err := syscall.GetFileType(syscall.Stdin)
+	fileType, err := syscall.GetFileType(handle)
 	if err != nil {
 		return 0, sys.UnwrapOSError(err)
 	}
 	if fileType&syscall.FILE_TYPE_CHAR == 0 {
 		return -1, sys.ENOSYS
 	}
-	n, err := peekNamedPipe(handle)
-	if err == syscall.ERROR_BROKEN_PIPE {
+	n, errno := peekNamedPipe(handle)
+	if errno == syscall.ERROR_BROKEN_PIPE {
 		return 0, 0
 	}
 	if n == 0 {
@@ -42,24 +42,42 @@ func readFd(fd uintptr, buf []byte) (int, sys.Errno) {
 	return un, sys.UnwrapOSError(err)
 }
 
+func writeFd(fd uintptr, buf []byte) (int, sys.Errno) {
+	return -1, sys.ENOSYS
+}
+
+func readSocket(h syscall.Handle, buf []byte) (int, sys.Errno) {
+	var overlapped syscall.Overlapped
+	var done uint32
+	errno := syscall.ReadFile(h, buf, &done, &overlapped)
+	if errno == syscall.ERROR_IO_PENDING {
+		errno = sys.EAGAIN
+	}
+	return int(done), sys.UnwrapOSError(errno)
+}
+
+func writeSocket(fd uintptr, buf []byte) (int, sys.Errno) {
+	var done uint32
+	var overlapped syscall.Overlapped
+	errno := syscall.WriteFile(syscall.Handle(fd), buf, &done, &overlapped)
+	if errno == syscall.ERROR_IO_PENDING {
+		errno = syscall.EAGAIN
+	}
+	return int(done), sys.UnwrapOSError(errno)
+}
+
 // peekNamedPipe partially exposes PeekNamedPipe from the Win32 API
 // see https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe
-func peekNamedPipe(handle syscall.Handle) (uint32, error) {
+func peekNamedPipe(handle syscall.Handle) (uint32, syscall.Errno) {
 	var totalBytesAvail uint32
 	totalBytesPtr := unsafe.Pointer(&totalBytesAvail)
-	_, _, err := procPeekNamedPipe.Call(
+	_, _, errno := syscall.SyscallN(
+		procPeekNamedPipe.Addr(),
 		uintptr(handle),        // [in]            HANDLE  hNamedPipe,
 		0,                      // [out, optional] LPVOID  lpBuffer,
 		0,                      // [in]            DWORD   nBufferSize,
 		0,                      // [out, optional] LPDWORD lpBytesRead
 		uintptr(totalBytesPtr), // [out, optional] LPDWORD lpTotalBytesAvail,
 		0)                      // [out, optional] LPDWORD lpBytesLeftThisMessage
-	if err == syscall.Errno(0) {
-		return totalBytesAvail, nil
-	}
-	return totalBytesAvail, err
-}
-
-func writeFd(fd uintptr, buf []byte) (int, sys.Errno) {
-	return -1, sys.ENOSYS
+	return totalBytesAvail, errno
 }

--- a/internal/sysfs/select_test.go
+++ b/internal/sysfs/select_test.go
@@ -75,12 +75,6 @@ func TestSelect(t *testing.T) {
 
 		for {
 			n, err := _select(fd+1, rFdSet, nil, nil, nil)
-			if runtime.GOOS == "windows" {
-				// Not implemented for fds != wasiFdStdin
-				require.ErrorIs(t, err, sys.ENOSYS)
-				require.Equal(t, -1, n)
-				break
-			}
 			if err == sys.EINTR {
 				t.Log("Select interrupted")
 				continue

--- a/internal/sysfs/select_windows.go
+++ b/internal/sysfs/select_windows.go
@@ -4,30 +4,26 @@ import (
 	"context"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/tetratelabs/wazero/experimental/sys"
 	"github.com/tetratelabs/wazero/internal/platform"
 )
 
-// wasiFdStdin is the constant value for stdin on Wasi.
-// We need this constant because on Windows os.Stdin.Fd() != 0.
-const wasiFdStdin = 0
-
-// pollInterval is the interval between each calls to peekNamedPipe in pollNamedPipe
+// pollInterval is the interval between each calls to peekNamedPipe in selectAllHandles
 const pollInterval = 100 * time.Millisecond
 
-// syscall_select emulates the select syscall on Windows for two, well-known cases, returns sys.ENOSYS for all others.
-// If r contains fd 0, and it is a regular file, then it immediately returns 1 (data ready on stdin)
-// and r will have the fd 0 bit set.
-// If r contains fd 0, and it is a FILE_TYPE_CHAR, then it invokes PeekNamedPipe to check the buffer for input;
-// if there is data ready, then it returns 1 and r will have fd 0 bit set.
+// syscall_select emulates the select syscall on Windows, for a subset of cases.
+//
+// r, w, e may contain any number of file handles, but regular files and pipes are only processed for r (Read).
+// Stdin is a pipe, thus it is checked for readiness when present. Pipes are checked using PeekNamedPipe.
+// Regular files always immediately report as ready, regardless their actual state and timeouts.
+//
 // If n==0 it will wait for the given timeout duration, but it will return sys.ENOSYS if timeout is nil,
 // i.e. it won't block indefinitely.
 //
-// Note: idea taken from https://stackoverflow.com/questions/6839508/test-if-stdin-has-input-for-c-windows-and-or-linux
+// Note: ideas taken from https://stackoverflow.com/questions/6839508/test-if-stdin-has-input-for-c-windows-and-or-linux
 // PeekNamedPipe: https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe
-// "GetFileType can assist in determining what device type the handle refers to. A console handle presents as FILE_TYPE_CHAR."
-// https://learn.microsoft.com/en-us/windows/console/console-handles
 func syscall_select(n int, r, w, e *platform.FdSet, timeout *time.Duration) (int, error) {
 	if n == 0 {
 		// Don't block indefinitely.
@@ -37,69 +33,181 @@ func syscall_select(n int, r, w, e *platform.FdSet, timeout *time.Duration) (int
 		time.Sleep(*timeout)
 		return 0, nil
 	}
-	if r.IsSet(wasiFdStdin) {
-		fileType, err := syscall.GetFileType(syscall.Stdin)
-		if err != nil {
-			return 0, err
-		}
-		if fileType&syscall.FILE_TYPE_CHAR != 0 {
-			res, err := pollNamedPipe(context.TODO(), syscall.Stdin, timeout)
-			if err != nil {
-				return -1, err
-			}
-			if !res {
-				r.Zero()
-				return 0, nil
-			}
-		}
-		r.Zero()
-		r.Set(wasiFdStdin)
-		return 1, nil
+
+	n, errno := selectAllHandles(context.TODO(), r, w, e, timeout)
+	if errno == 0 {
+		return n, nil
 	}
-	return -1, sys.ENOSYS
+	return n, errno
 }
 
-// pollNamedPipe polls the given named pipe handle for the given duration.
+// selectAllHandles emulates a general-purpose POSIX select on Windows.
 //
 // The implementation actually polls every 100 milliseconds until it reaches the given duration.
 // The duration may be nil, in which case it will wait undefinely. The given ctx is
-// used to allow for cancellation. Currently used only in tests.
-func pollNamedPipe(ctx context.Context, pipeHandle syscall.Handle, duration *time.Duration) (bool, error) {
+// used to allow for cancellation, and it is currently used only in tests.
+//
+// As indicated in the man page for select [1], r, w, e are modified upon completion:
+//
+// "Upon successful completion, the pselect() or select() function shall modify the objects pointed to by the readfds,
+// writefds, and errorfds arguments to indicate which file descriptors are ready for reading, ready for writing,
+// or have an error condition pending, respectively, and shall return the total number of ready descriptors in all the output sets"
+//
+// However, for our purposes, this may be pedantic because currently we do not check the values of r, w, e
+// after the invocation of select; thus, this behavior may be subject to change in the future for the sake of simplicity.
+//
+// [1]: https://linux.die.net/man/3/select
+func selectAllHandles(ctx context.Context, r, w, e *platform.FdSet, duration *time.Duration) (int, sys.Errno) {
+	nregular := r.Regular().Count() + w.Regular().Count() + e.Regular().Count()
+
+	nsocks := 0
+
+	rp, errno := peekAllPipes(r.Pipes())
+	npipes := rp.Count()
+
+	if errno != 0 {
+		r.Zero()
+		w.Zero()
+		e.Zero()
+		r.SetPipes(*rp)
+		return nregular + npipes, errno
+	}
+
+	// winsock_select mutates the given references, so we create copies.
+	rs, ws, es := r.Sockets().Copy(), w.Sockets().Copy(), e.Sockets().Copy()
+
 	// Short circuit when the duration is zero.
 	if duration != nil && *duration == time.Duration(0) {
-		bytes, err := peekNamedPipe(pipeHandle)
-		return bytes > 0, err
-	}
+		nsocks, errno = winsock_select(rs, ws, es, duration)
+	} else {
+		// Ticker that emits at every pollInterval.
+		tick := time.NewTicker(pollInterval)
+		tickCh := tick.C
+		defer tick.Stop()
 
-	// Ticker that emits at every pollInterval.
-	tick := time.NewTicker(pollInterval)
-	tichCh := tick.C
-	defer tick.Stop()
+		// Timer that expires after the given duration.
+		// Initialize afterCh as nil: the select below will wait forever.
+		var afterCh <-chan time.Time
+		if duration != nil {
+			// If duration is not nil, instantiate the timer.
+			after := time.NewTimer(*duration)
+			defer after.Stop()
+			afterCh = after.C
+		}
 
-	// Timer that expires after the given duration.
-	// Initialize afterCh as nil: the select below will wait forever.
-	var afterCh <-chan time.Time
-	if duration != nil {
-		// If duration is not nil, instantiate the timer.
-		after := time.NewTimer(*duration)
-		defer after.Stop()
-		afterCh = after.C
-	}
+		// winsock_select is a blocking call. We spin a goroutine
+		// and write back to a channel the result. We consume
+		// this result in the for loop together with the polling
+		// routines.
+		type selectResult struct {
+			n     int
+			errno sys.Errno
+		}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return false, nil
-		case <-afterCh:
-			return false, nil
-		case <-tichCh:
-			res, err := peekNamedPipe(pipeHandle)
-			if err != nil {
-				return false, err
-			}
-			if res > 0 {
-				return true, nil
+		winsockSelectCh := make(chan selectResult, 1)
+		defer close(winsockSelectCh)
+
+		go func() {
+			res := selectResult{}
+			res.n, res.errno = winsock_select(rs, ws, es, duration)
+			winsockSelectCh <- res
+		}()
+
+		nsocks := 0
+
+	outer:
+		for {
+			select {
+			case <-ctx.Done():
+				break outer
+			case <-afterCh:
+				break outer
+			case <-tickCh:
+				rp, errno = peekAllPipes(r.Pipes())
+				npipes = rp.Count()
+				if errno != 0 || npipes > 0 {
+					break outer
+				}
+			case res := <-winsockSelectCh:
+				nsocks = res.n
+				if res.errno != 0 {
+					break outer
+				}
+				// winsock_select has returned with no result, ignore
+				// and wait for the other pipes.
+				if nsocks == 0 {
+					continue
+				}
+				// If select has return successfully we peek for the last time at the other pipes
+				// to see if data is available and return the sum.
+				rp, errno = peekAllPipes(r.Pipes())
+				npipes = rp.Count()
+				break outer
 			}
 		}
 	}
+
+	rr, wr, er := r.Regular().Copy(), w.Regular().Copy(), e.Regular().Copy()
+
+	// Clear all FdSets and set them in accordance to the returned values.
+
+	if r != nil {
+		// Pipes are handled only for r
+		r.SetPipes(*rp)
+		r.SetRegular(*rr)
+		r.SetSockets(*rs)
+	}
+
+	if w != nil {
+		w.SetRegular(*wr)
+		w.SetSockets(*ws)
+	}
+
+	if e != nil {
+		e.SetRegular(*er)
+		e.SetSockets(*es)
+	}
+
+	return nregular + npipes + nsocks, errno
+}
+
+func peekAllPipes(pipeHandles *platform.WinSockFdSet) (*platform.WinSockFdSet, sys.Errno) {
+	ready := &platform.WinSockFdSet{}
+	for i := 0; i < pipeHandles.Count(); i++ {
+		h := pipeHandles.Get(i)
+		bytes, errno := peekNamedPipe(h)
+		if bytes > 0 {
+			ready.Set(int(h))
+		}
+		if errno != 0 {
+			return ready, sys.UnwrapOSError(errno)
+		}
+	}
+	return ready, 0
+}
+
+func winsock_select(r, w, e *platform.WinSockFdSet, timeout *time.Duration) (int, sys.Errno) {
+	if r.Count() == 0 && w.Count() == 0 && e.Count() == 0 {
+		return 0, 0
+	}
+
+	var t *syscall.Timeval
+	if timeout != nil {
+		tv := syscall.NsecToTimeval(timeout.Nanoseconds())
+		t = &tv
+	}
+
+	rp := unsafe.Pointer(r)
+	wp := unsafe.Pointer(w)
+	ep := unsafe.Pointer(e)
+	tp := unsafe.Pointer(t)
+
+	r0, _, err := syscall.SyscallN(
+		procselect.Addr(),
+		uintptr(0), // the first argument is ignored and exists only for compat with BSD sockets.
+		uintptr(rp),
+		uintptr(wp),
+		uintptr(ep),
+		uintptr(tp))
+	return int(r0), sys.UnwrapOSError(err)
 }

--- a/internal/sysfs/sock_windows.go
+++ b/internal/sysfs/sock_windows.go
@@ -5,21 +5,35 @@ package sysfs
 import (
 	"net"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/platform"
 	socketapi "github.com/tetratelabs/wazero/internal/sock"
 )
 
-// MSG_PEEK is the flag PEEK for syscall.Recvfrom on Windows.
-// This constant is not exported on this platform.
-const MSG_PEEK = 0x2
+const (
+	// MSG_PEEK is the flag PEEK for syscall.Recvfrom on Windows.
+	// This constant is not exported on this platform.
+	MSG_PEEK = 0x2
+	// _FIONBIO is the flag to set the O_NONBLOCK flag on socket handles using ioctlsocket.
+	_FIONBIO = 0x8004667e
+	// _WASWOULDBLOCK corresponds to syscall.EWOULDBLOCK in WinSock.
+	_WASWOULDBLOCK = 10035
+)
 
 var (
 	// modws2_32 is WinSock.
 	modws2_32 = syscall.NewLazyDLL("ws2_32.dll")
 	// procrecvfrom exposes recvfrom from WinSock.
 	procrecvfrom = modws2_32.NewProc("recvfrom")
+	// procaccept exposes accept from WinSock.
+	procaccept = modws2_32.NewProc("accept")
+	// procioctlsocket exposes ioctlsocket from WinSock.
+	procioctlsocket = modws2_32.NewProc("ioctlsocket")
+	// procselect exposes select from WinSock.
+	procselect = modws2_32.NewProc("select")
 )
 
 // recvfrom exposes the underlying syscall in Windows.
@@ -28,7 +42,7 @@ var (
 // we do not need really need all the parameters that are actually
 // allowed in WinSock.
 // We ignore `from *sockaddr` and `fromlen *int`.
-func recvfrom(s syscall.Handle, buf []byte, flags int32) (n int, errno syscall.Errno) {
+func recvfrom(s syscall.Handle, buf []byte, flags int32) (n int, errno sys.Errno) {
 	var _p0 *byte
 	if len(buf) > 0 {
 		_p0 = &buf[0]
@@ -41,7 +55,41 @@ func recvfrom(s syscall.Handle, buf []byte, flags int32) (n int, errno syscall.E
 		uintptr(flags),
 		0, // from *sockaddr (optional)
 		0) // fromlen *int (optional)
-	return int(r0), e1
+	return int(r0), sys.UnwrapOSError(e1)
+}
+
+func setNonblockSocket(fd syscall.Handle, enabled bool) sys.Errno {
+	opt := uint64(0)
+	if enabled {
+		opt = 1
+	}
+	// ioctlsocket(fd, FIONBIO, &opt)
+	_, _, errno := syscall.SyscallN(
+		procioctlsocket.Addr(),
+		uintptr(fd),
+		uintptr(_FIONBIO),
+		uintptr(unsafe.Pointer(&opt)))
+	return sys.UnwrapOSError(errno)
+}
+
+// syscallConnControl extracts a syscall.RawConn from the given syscall.Conn and applies
+// the given fn to a file descriptor, returning an integer or a nonzero syscall.Errno on failure.
+//
+// syscallConnControl streamlines the pattern of extracting the syscall.Rawconn,
+// invoking its syscall.RawConn.Control method, then handling properly the errors that may occur
+// within fn or returned by syscall.RawConn.Control itself.
+func syscallConnControl(conn syscall.Conn, fn func(fd uintptr) (int, sys.Errno)) (n int, errno sys.Errno) {
+	syscallConn, err := conn.SyscallConn()
+	if err != nil {
+		return 0, sys.UnwrapOSError(err)
+	}
+	// Prioritize the inner errno over Control
+	if controlErr := syscallConn.Control(func(fd uintptr) {
+		n, errno = fn(fd)
+	}); errno == 0 {
+		errno = sys.UnwrapOSError(controlErr)
+	}
+	return
 }
 
 // newTCPListenerFile is a constructor for a socketapi.TCPSock.
@@ -53,7 +101,9 @@ func recvfrom(s syscall.Handle, buf []byte, flags int32) (n int, errno syscall.E
 // standard library, instead of invoke syscalls/Win32 APIs
 // because they are sensibly different from Unix's.
 func newTCPListenerFile(tl *net.TCPListener) socketapi.TCPSock {
-	return &winTcpListenerFile{tl: tl}
+	w := &winTcpListenerFile{tl: tl}
+	_ = w.SetNonblock(true)
+	return w
 }
 
 var _ socketapi.TCPSock = (*winTcpListenerFile)(nil)
@@ -61,26 +111,56 @@ var _ socketapi.TCPSock = (*winTcpListenerFile)(nil)
 type winTcpListenerFile struct {
 	baseSockFile
 
-	tl *net.TCPListener
+	tl       *net.TCPListener
+	closed   bool
+	nonblock bool
 }
 
 // Accept implements the same method as documented on socketapi.TCPSock
 func (f *winTcpListenerFile) Accept() (socketapi.TCPConn, sys.Errno) {
-	conn, err := f.tl.Accept()
-	if err != nil {
-		return nil, sys.UnwrapOSError(err)
+	// Ensure we have an incoming connection using winsock_select.
+	n, errno := syscallConnControl(f.tl, func(fd uintptr) (int, sys.Errno) {
+		fdSet := platform.WinSockFdSet{}
+		fdSet.Set(int(fd))
+		t := time.Duration(0)
+		return winsock_select(&fdSet, nil, nil, &t)
+	})
+
+	// Otherwise return immediately.
+	if n == 0 || errno != 0 {
+		return nil, sys.EAGAIN
 	}
-	return &winTcpConnFile{tc: conn.(*net.TCPConn)}, 0
+
+	// Accept normally blocks goroutines, but we
+	// made sure that we have an incoming connection,
+	// so we should be safe.
+	if conn, err := f.tl.Accept(); err != nil {
+		return nil, sys.UnwrapOSError(err)
+	} else {
+		return newTcpConn(conn.(*net.TCPConn)), 0
+	}
+}
+
+// IsNonblock implements File.IsNonblock
+func (f *winTcpListenerFile) IsNonblock() bool {
+	return f.nonblock
 }
 
 // SetNonblock implements the same method as documented on fsapi.File
 func (f *winTcpListenerFile) SetNonblock(enabled bool) sys.Errno {
-	return 0 // setNonblock() is a no-op on Windows
+	f.nonblock = enabled
+	_, errno := syscallConnControl(f.tl, func(fd uintptr) (int, sys.Errno) {
+		return 0, setNonblockSocket(syscall.Handle(fd), enabled)
+	})
+	return errno
 }
 
 // Close implements the same method as documented on fsapi.File
 func (f *winTcpListenerFile) Close() sys.Errno {
-	return sys.UnwrapOSError(f.tl.Close())
+	if !f.closed {
+		return sys.UnwrapOSError(f.tl.Close())
+	}
+	return 0
 }
 
 // Addr is exposed for testing.
@@ -90,12 +170,18 @@ func (f *winTcpListenerFile) Addr() *net.TCPAddr {
 
 var _ socketapi.TCPConn = (*winTcpConnFile)(nil)
 
+// winTcpConnFile is a blocking connection.
+//
+// It is a wrapper for an underlying net.TCPConn.
 type winTcpConnFile struct {
 	baseSockFile
 
 	tc *net.TCPConn
 
-	// closed is true when closed was called. This ensures proper sys.EBADF
+	// nonblock is true when the underlying connection is flagged as non-blocking.
+	// This ensures that reads and writes return EAGAIN without blocking the caller.
+	nonblock bool
+	// closed is true when closed was called. This ensures proper syscall.EBADF
 	closed bool
 }
 
@@ -105,23 +191,30 @@ func newTcpConn(tc *net.TCPConn) socketapi.TCPConn {
 
 // SetNonblock implements the same method as documented on fsapi.File
 func (f *winTcpConnFile) SetNonblock(enabled bool) (errno sys.Errno) {
-	syscallConn, err := f.tc.SyscallConn()
-	if err != nil {
-		return sys.UnwrapOSError(err)
-	}
-
-	// Prioritize the error from setNonblock over Control
-	if controlErr := syscallConn.Control(func(fd uintptr) {
-		errno = sys.UnwrapOSError(setNonblock(fd, enabled))
-	}); errno == 0 {
-		errno = sys.UnwrapOSError(controlErr)
-	}
+	_, errno = syscallConnControl(f.tc, func(fd uintptr) (int, sys.Errno) {
+		return 0, sys.UnwrapOSError(setNonblockSocket(syscall.Handle(fd), enabled))
+	})
 	return
+}
+
+// IsNonblock implements File.IsNonblock
+func (f *winTcpConnFile) IsNonblock() bool {
+	return f.nonblock
 }
 
 // Read implements the same method as documented on fsapi.File
 func (f *winTcpConnFile) Read(buf []byte) (n int, errno sys.Errno) {
-	if n, errno = read(f.tc, buf); errno != 0 {
+	if len(buf) == 0 {
+		return 0, 0 // Short-circuit 0-len reads.
+	}
+	if nonBlockingFileReadSupported && f.IsNonblock() {
+		n, errno = syscallConnControl(f.tc, func(fd uintptr) (int, sys.Errno) {
+			return readSocket(syscall.Handle(fd), buf)
+		})
+	} else {
+		n, errno = read(f.tc, buf)
+	}
+	if errno != 0 {
 		// Defer validation overhead until we've already had an error.
 		errno = fileError(f, f.closed, errno)
 	}
@@ -130,7 +223,14 @@ func (f *winTcpConnFile) Read(buf []byte) (n int, errno sys.Errno) {
 
 // Write implements the same method as documented on fsapi.File
 func (f *winTcpConnFile) Write(buf []byte) (n int, errno sys.Errno) {
-	if n, errno = write(f.tc, buf); errno != 0 {
+	if nonBlockingFileWriteSupported && f.IsNonblock() {
+		return syscallConnControl(f.tc, func(fd uintptr) (int, sys.Errno) {
+			return writeSocket(fd, buf)
+		})
+	} else {
+		n, errno = write(f.tc, buf)
+	}
+	if errno != 0 {
 		// Defer validation overhead until we've already had an error.
 		errno = fileError(f, f.closed, errno)
 	}
@@ -143,22 +243,9 @@ func (f *winTcpConnFile) Recvfrom(p []byte, flags int) (n int, errno sys.Errno) 
 		errno = sys.EINVAL
 		return
 	}
-	conn := f.tc
-	syscallConn, err := conn.SyscallConn()
-	if err != nil {
-		errno = sys.UnwrapOSError(err)
-		return
-	}
-
-	// Prioritize the error from recvfrom over Control
-	if controlErr := syscallConn.Control(func(fd uintptr) {
-		var recvfromErr error
-		n, recvfromErr = recvfrom(syscall.Handle(fd), p, MSG_PEEK)
-		errno = sys.UnwrapOSError(recvfromErr)
-	}); errno == 0 {
-		errno = sys.UnwrapOSError(controlErr)
-	}
-	return
+	return syscallConnControl(f.tc, func(fd uintptr) (int, sys.Errno) {
+		return recvfrom(syscall.Handle(fd), p, MSG_PEEK)
+	})
 }
 
 // Shutdown implements the same method as documented on fsapi.Conn


### PR DESCRIPTION
Further work to improve the support to nonblocking I/O on Windows. This drops the special-casing for stdin, and instead checks if a handle is a named pipe (which includes sockets and other kinds of pipes); moreover it further improve _select by introducing a proper wrapper for winsock's select, which is BSD socket's select, and a compatible implementation of FdSet.